### PR TITLE
🛠️ Various fixes

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -235,30 +235,6 @@ body,
   z-index: -1;
 }
 
-.hours-table {
-  background: transparent;
-}
-
-table {
-  margin-top: 1rem;
-}
-
-td {
-  border-bottom: 0px;
-}
-
-td:first-child {
-  padding-left: 5px;
-}
-td:last-child {
-  padding-right: 5px;
-}
-
-tbody tr td:last-child,
-thead tr th:last-child {
-  border-left: 1px solid black;
-}
-
 @media (max-width: 768px) {
   .bg-fade {
     background-image: linear-gradient(to bottom, #00000000 0, #ffffff 30%);

--- a/public/pages/team.html
+++ b/public/pages/team.html
@@ -1,17 +1,20 @@
-<div class="py-4 min-w-screen pt-24">
-	<h1 class="font-bold text-7xl p-4 text-center">
-		<i class="bi bi-people mx-auto text-black"></i>
-	</h1>
-	<h1 class="font-bold text-center text-5xl lg:text-7xl text-black my-2">
-		Our <span class="bg-jt-grad-text">Team</span>
-	</h1>
-	<h1 class="text-center text-xl font-medium italic text-gray-700 mx-4">
-		Meet the people who make JT Hair the best place for your hair care needs.
-	</h1>
+<div>
+	<div class="py-4 min-w-screen pt-24">
+		<h1 class="font-bold text-7xl p-4 text-center">
+			<i class="bi bi-people mx-auto text-black"></i>
+		</h1>
+		<h1 class="font-bold text-center text-5xl lg:text-7xl text-black my-2">
+			Our <span class="bg-jt-grad-text">Team</span>
+		</h1>
+		<h1 class="text-center text-xl font-medium italic text-gray-700 mx-4">
+			Meet the people who make JT Hair the best place for your hair care needs.
+		</h1>
+	</div>
+	<div class="hidden max-sm:block">
+		<jt-staff-list></jt-staff-list>
+	</div>
+	<div class="hidden sm:block">
+		<jt-staff-carousel></jt-staff-carousel>
+	</div>
 </div>
-<div class="hidden max-sm:block">
-	<jt-staff-list></jt-staff-list>
-</div>
-<div class="hidden sm:block">
-	<jt-staff-carousel></jt-staff-carousel>
-</div>
+

--- a/src/components/jt-hours-table.js
+++ b/src/components/jt-hours-table.js
@@ -4,6 +4,26 @@ const JTHoursTableTemplate = document.createElement("template");
 JTHoursTableTemplate.innerHTML = `
     <style>
         ${stylesheet}
+        .hours-table {
+            background: transparent;
+        }
+        table {
+            margin-top: 1rem;
+        }
+        td {
+            border-bottom: 0px;
+        }
+        td:first-child {
+            padding-left: 5px;
+        }
+        td:last-child {
+            min-width: 130px;
+            padding-right: 5px;
+        }
+        tbody tr td:last-child,
+        thead tr th:last-child {
+            border-left: 1px solid black;
+        }
         .openHour{
         	min-width: 130px;
         }

--- a/src/components/jt-service-list.js
+++ b/src/components/jt-service-list.js
@@ -90,7 +90,7 @@ class JtServiceList extends HTMLElement {
 		});
 
 		this.shiftHeader = (e) => {
-			if(window.scrollY > 325){
+			if(window.scrollY > 280){
 				this.serviceBanner.classList.add('expand')
 			} else {
 				this.serviceBanner.classList.remove('expand')

--- a/src/components/jt-staff-carousel.js
+++ b/src/components/jt-staff-carousel.js
@@ -25,7 +25,7 @@ JTStaffCarouselTemplate.innerHTML = `
             opacity: 1;
         }
     </style>
-    <div class="carousel carousel-center mx-auto w-full gap-8 overflow-y-hidden cursor-grab select-none" id="staffCarousel" style="scroll-behavior: smooth;"></div>
+    <div class="carousel carousel-center mx-auto mt-16 w-full gap-8 overflow-y-hidden cursor-grab select-none" id="staffCarousel" style="scroll-behavior: smooth;"></div>
 `;
 class JTStaffCarousel extends HTMLElement {
 	constructor() {

--- a/src/router.js
+++ b/src/router.js
@@ -55,14 +55,6 @@ const changePage = async () => {
     pageRoot.appendChild(fragment.body.children[0]);
     document.title = 'JT Hair Care of Brighton | ' + title;
     document.querySelector('meta[name="description"]').setAttribute('content', description)
-    document.querySelectorAll('a.inner-navlink').forEach((el) => {
-        el.addEventListener('click', (e) => {
-            e.preventDefault();
-            window.history.pushState({}, "", e.target.href);
-            document.querySelector('jt-navbar').setActiveLink(e.target.href);
-            handleLocation();
-        });
-    })
 }
 
 const handleLocation = async (force) => {
@@ -77,6 +69,14 @@ const handleLocation = async (force) => {
     } else {
         await changePage();
         pageRoot.classList.add('slide-in-bottom-longer');
+        document.querySelectorAll('a.inner-navlink').forEach((el) => {
+            el.addEventListener('click', (e) => {
+                e.preventDefault();
+                window.history.pushState({}, "", e.target.href);
+                document.querySelector('jt-navbar').setActiveLink(e.target.href);
+                handleLocation();
+            });
+        })
     }
 }
 

--- a/src/router.js
+++ b/src/router.js
@@ -40,13 +40,20 @@ const changePage = async () => {
     const route = routes[window.location.pathname] || window.location.pathname + '.html';
     const title = pageTitles[window.location.pathname] || pageTitles[404];
     const description = pageDescriptions[window.location.pathname] || pageDescriptions[404];
-    pageRoot.innerHTML = await fetch(route).then(async (data) => {
-        if(!data.ok){
-            return await fetch(routes[404]).then((data) => data.text());
-        } else {
-            return data.text();
+    pageRoot.innerHTML = ""
+    let fragment = new DOMParser().parseFromString(
+        await fetch(route).then(async (data) => {
+            if(!data.ok){
+                return await fetch(routes[404]).then((data) => data.text());
+            } else {
+                return data.text();
+            }
+        }), 'text/html', {
+            includeShadowRoots: true
         }
-    });    document.title = 'JT Hair Care of Brighton | ' + title;
+    );
+    pageRoot.appendChild(fragment.body.children[0]);
+    document.title = 'JT Hair Care of Brighton | ' + title;
     document.querySelector('meta[name="description"]').setAttribute('content', description)
     document.querySelectorAll('a.inner-navlink').forEach((el) => {
         el.addEventListener('click', (e) => {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -254,27 +254,3 @@ body,
 .bg-fade {
 	z-index: -1;
 }
-
-.hours-table {
-	background: transparent;
-}
-
-table {
-	margin-top: 1rem;
-}
-
-td {
-	border-bottom: 0px;
-}
-
-td:first-child {
-	padding-right: 20px;
-}
-td:last-child {
-	padding-left: 20px;
-}
-
-tbody tr td:last-child,
-thead tr th:last-child {
-	border-left: 1px solid black;
-}


### PR DESCRIPTION
- Decrease scroll threshold for the shifting header in the service list. This eliminates an edge case where clicking on the children's option scrolls the page but does not activate the header.
- Rewrite the router logic to use the DOM Parser and document fragments to insert (safe?) HTML instead of a string using innerHTML. I did this to test Declarative Shadow DOM on my components but I'm keeping the logic because I assume it's safer. *This change will require all pages to have a single root element*
- Refactor the styles for the hours table from the global stylesheet into the component. Also done during my DSD tests.
- Add a wrapper root element on the team page to conform to restrictions introduced in the DOM Parser router change (see above)